### PR TITLE
Fix linting and spelling errors in source code

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: >
         Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
-        sure you are using the latest version of the charm. If not, please switch to the lastest version of this charm
+        sure you are using the latest version of the charm. If not, please switch to the latest version of this charm
         before posting your report to make sure it's not already solved.
   - type: textarea
     id: bug-description

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,10 +17,9 @@
 
 import pathlib
 
+from helpers import ETCD, NHC, VERSION
 from pytest import fixture
 from pytest_operator.plugin import OpsTest
-
-from helpers import ETCD, NHC, VERSION
 
 
 @fixture(scope="module")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -19,7 +19,6 @@ import logging
 import pathlib
 import shlex
 import subprocess
-
 from typing import Dict
 from urllib import request
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -18,15 +18,15 @@
 import asyncio
 import logging
 import pathlib
+from typing import Any, Coroutine
+
 import pytest
 import tenacity
-
 from helpers import (
     get_slurmctld_res,
     get_slurmd_res,
 )
 from pytest_operator.plugin import OpsTest
-from typing import Any, Coroutine
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ async def test_build_and_deploy(
             series="bionic",
         ),
     )
-    
+
     # Attach ETCD resource to the slurmctld controller
     await ops_test.juju("attach-resource", SLURMCTLD, f"etcd={res_slurmctld['etcd']}")
 
@@ -127,7 +127,7 @@ async def test_munge_is_active(ops_test: OpsTest) -> None:
 
 # IMPORTANT: Currently there is a bug where slurmrestd can reach active status despite the
 # systemd service failing. Error is "unable to get address" and "Temporary failure in
-# name resolution". 
+# name resolution".
 @pytest.mark.xfail
 @tenacity.retry(
     wait=tenacity.wait.wait_exponential(multiplier=2, min=1, max=30),


### PR DESCRIPTION
## Description

Fixed flagged linting errors caught by the `tox -e lint` command. Lint test should now be passing.

## How was the code tested?

Both "tox -e fmt" and "tox -e lint" run on Ubuntu 22.04 LTS.

## Related issues and/or tasks

See related Projects

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.
